### PR TITLE
オプション機能「提督名をマスク」「司令部ベレルをマスク」を追加

### DIFF
--- a/kanmusumemory_global.h
+++ b/kanmusumemory_global.h
@@ -34,6 +34,8 @@
 #define SETTING_GENERAL_SCREEN_NAME "screen_name"
 #define SETTING_GENERAL_UNUSED_TWITTER  "unused_twitter"
 #define SETTING_GENERAL_SAVE_PNG    "save_png"
+#define SETTING_GENERAL_MASK_ADMIRAL_NAME   "mask_admiral_name"
+#define SETTING_GENERAL_MASK_HQ_LEVEL       "mask_hq_level"
 
 #define SETTING_MAINWINDOW          "mainwindow"
 #define SETTING_TIMERDIALOG         "timerdialog"

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -113,11 +113,15 @@ MainWindow::Private::Private(MainWindow *parent)
         dlg.setSavePath(settings.value(QStringLiteral("path")).toString());
         dlg.setUnusedTwitter(settings.value(SETTING_GENERAL_UNUSED_TWITTER, false).toBool());
         dlg.setSavePng(settings.value(SETTING_GENERAL_SAVE_PNG, false).toBool());
+        dlg.setMaskAdmiralName(settings.value(SETTING_GENERAL_MASK_ADMIRAL_NAME, false).toBool());
+        dlg.setMaskHqLevel(settings.value(SETTING_GENERAL_MASK_HQ_LEVEL, false).toBool());
         if (dlg.exec()) {
             //設定更新
             settings.setValue(QStringLiteral("path"), dlg.savePath());
             settings.setValue(SETTING_GENERAL_UNUSED_TWITTER, dlg.unusedTwitter());
             settings.setValue(SETTING_GENERAL_SAVE_PNG, dlg.savePng());
+            settings.setValue(SETTING_GENERAL_MASK_ADMIRAL_NAME, dlg.isMaskAdmiralName());
+            settings.setValue(SETTING_GENERAL_MASK_HQ_LEVEL, dlg.isMaskHqLevel());
         }
     });
 
@@ -228,6 +232,27 @@ void MainWindow::Private::captureGame()
     {
         ui.statusBar->showMessage(tr("failed capture image"), STATUS_BAR_MSG_TIME);
         return;
+    }
+
+    //提督名をマスク
+    static const QRgb maskPixel = qRgb(0, 0, 32);
+    if(settings.value(SETTING_GENERAL_MASK_ADMIRAL_NAME, false).toBool())
+    {
+        for(int x=124; x<270; x++){
+            for(int y=8; y<24; y++){
+                img.setPixel(x, y, maskPixel);
+            }
+        }
+    }
+
+    //司令部レベルをマスク
+    if(settings.value(SETTING_GENERAL_MASK_HQ_LEVEL, false).toBool())
+    {
+        for(int x=392; x<480; x++){
+            for(int y=13; y<29; y++){
+                img.setPixel(x, y, maskPixel);
+            }
+        }
     }
 
     char format[4] = {0};

--- a/settingsdialog.cpp
+++ b/settingsdialog.cpp
@@ -74,6 +74,26 @@ void SettingsDialog::setSavePng(bool savePng)
     ui->savePngCheckBox->setChecked(savePng);
 }
 
+bool SettingsDialog::isMaskAdmiralName() const
+{
+    return m_maskAdmiralName;
+}
+void SettingsDialog::setMaskAdmiralName(bool b)
+{
+    m_maskAdmiralName = b;
+    ui->maskAdmiralNameCheckBox->setChecked(b);
+}
+
+bool SettingsDialog::isMaskHqLevel() const
+{
+    return m_maskHqLevel;
+}
+void SettingsDialog::setMaskHqLevel(bool b)
+{
+    m_maskHqLevel = b;
+    ui->maskHqLevelCheckBox->setChecked(b);
+}
+
 
 void SettingsDialog::on_okButton_clicked()
 {
@@ -85,6 +105,8 @@ void SettingsDialog::on_okButton_clicked()
     m_savePath = ui->savePathEdit->text();
     m_unusedTwitter = ui->unusedTwittercheckBox->isChecked();
     m_savePng = ui->savePngCheckBox->isChecked();
+    m_maskAdmiralName = ui->maskAdmiralNameCheckBox->isChecked();
+    m_maskHqLevel = ui->maskHqLevelCheckBox->isChecked();
 
     accept();
 }

--- a/settingsdialog.h
+++ b/settingsdialog.h
@@ -41,6 +41,12 @@ public:
     bool savePng() const;
     void setSavePng(bool savePng);
 
+    bool isMaskAdmiralName() const;
+    void setMaskAdmiralName(bool b);
+
+    bool isMaskHqLevel() const;
+    void setMaskHqLevel(bool b);
+
 private slots:
     void on_okButton_clicked();
 
@@ -54,6 +60,8 @@ private:
     QString m_savePath;
     bool m_unusedTwitter;
     bool m_savePng;
+    bool m_maskAdmiralName;
+    bool m_maskHqLevel;
 };
 
 #endif // SETTINGSDIALOG_H

--- a/settingsdialog.ui
+++ b/settingsdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>169</height>
+    <height>220</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -27,7 +27,7 @@
    <property name="geometry">
     <rect>
      <x>200</x>
-     <y>130</y>
+     <y>180</y>
      <width>75</width>
      <height>31</height>
     </rect>
@@ -40,7 +40,7 @@
    <property name="geometry">
     <rect>
      <x>290</x>
-     <y>130</y>
+     <y>180</y>
      <width>75</width>
      <height>31</height>
     </rect>
@@ -105,6 +105,44 @@
    </property>
    <property name="text">
     <string>Save in PNG format.</string>
+   </property>
+  </widget>
+  <widget class="QCheckBox" name="maskAdmiralNameCheckBox">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>130</y>
+     <width>191</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="maximumSize">
+    <size>
+     <width>16777215</width>
+     <height>16777215</height>
+    </size>
+   </property>
+   <property name="text">
+    <string>Mask Admiral name</string>
+   </property>
+  </widget>
+  <widget class="QCheckBox" name="maskHqLevelCheckBox">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>160</y>
+     <width>191</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="maximumSize">
+    <size>
+     <width>16777215</width>
+     <height>16777215</height>
+    </size>
+   </property>
+   <property name="text">
+    <string>Mask HQ level</string>
    </property>
   </widget>
  </widget>


### PR DESCRIPTION
1.Preferencesダイアログに、"Mask Admiral name"と"Mask HQ level"、２つのチェックボックスを追加
2.スクリーンショット撮影時に、オプションが有効なら提督名と司令部レベルをマスク（黒塗り）します

補足
- 執務室画面かどうかに関わらずマスクしていまいます
- 先のstrcpy_s()のブランチの延長で修正したため、このpull-reqにも同じ修正が混入してしまいました。すいません
