### PR TITLE
Move "twitterinfo.h" into project directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ Thumbs.db
 # Mac OS X
 .DS_Store
 KanmusuMemory.app/
+
+# Twitter Consumer Key and Secret
+twitterinfo.h

--- a/KanmusuMemory.pro
+++ b/KanmusuMemory.pro
@@ -26,7 +26,7 @@ SOURCES += main.cpp\
 
 HEADERS  += mainwindow.h \
     tweetdialog.h \
-    ../KanmusuMemoryTwitter/twitterinfo.h \
+    twitterinfo.h \
     settingsdialog.h \
     cookiejar.h \
     aboutdialog.h \

--- a/timerdialog.cpp
+++ b/timerdialog.cpp
@@ -16,7 +16,7 @@
 #include "timerdialog.h"
 #include "ui_timerdialog.h"
 #include "kanmusumemory_global.h"
-#include "../KanmusuMemoryTwitter/twitterinfo.h"
+#include "twitterinfo.h"
 
 #include <QQmlContext>
 #include <QQuickItem>

--- a/tweetdialog.cpp
+++ b/tweetdialog.cpp
@@ -22,7 +22,7 @@
 #include <QtTwitterAPI/oauth.h>
 #include <QtTwitterAPI/status.h>
 
-#include "../KanmusuMemoryTwitter/twitterinfo.h"
+#include "twitterinfo.h"
 
 class TweetDialog::Private
 {


### PR DESCRIPTION
`twitterinfo.h`の置き場所をプロジェクトルート内に移動したいです。

理由は、CIツールでビルドするときに自ジョブのワークスペース外にファイルを置くのに抵抗があるため。
ビルド環境（セットアップ手順）に影響が出るので、mergeは任意のタイミングで結構です。

before:
- "twitterinfo.h" was in "../KanmusuMemoryTwitter/" directory

after:
- "twitterinfo.h" is in this project root directory
- add "twitterinfo.h" to .gitignore
